### PR TITLE
'center entire feed' border continuity fix. Just CSS mod.

### DIFF
--- a/config.js
+++ b/config.js
@@ -150,9 +150,12 @@ const TWITTER_MODS = {
       styles: `
         margin: 0 auto !important;
         float: none !important;
+        width: 100% !important;
         max-width: 600px !important;
-        width: 600px !important;
-        flex: 0 1 600px !important;
+        flex-grow: 1 !important;
+        flex-basis: auto !important;
+        flex-direction: column !important;
+        flex-shrink: 0 !important;
         -webkit-box-flex: 0 !important;
       `
     },


### PR DESCRIPTION
fixed css for 'center entire feed', 'primary column' resynced with original twitter column css, everything else falls into place 
border grows with flexbox, and compose tweet area does not overextend onto border

Before:
<img width="127" alt="image" src="https://github.com/user-attachments/assets/fb741aee-aff8-4d83-9eb8-f92fe07c9e01" />
<img width="61" alt="image" src="https://github.com/user-attachments/assets/ad3ca1a7-17ad-4cd7-8e67-4f750e7ace74" />
<img width="216" alt="image" src="https://github.com/user-attachments/assets/e9b53451-c72c-43ba-8535-a3f4dcc5a46f" />

After:
<img width="800" alt="image" src="https://github.com/user-attachments/assets/35922c23-8c68-4a24-a682-c0de07c261e8" />
<img width="149" alt="image" src="https://github.com/user-attachments/assets/2b028369-9450-4560-8b74-8613953fa8bf" />


-gh 01/26/25 8:32EST