### PR TITLE
Extra selectors for non-english users, non-premium users

### DIFF
--- a/config.js
+++ b/config.js
@@ -54,6 +54,7 @@ const TWITTER_MODS = {
       description: "Hide Premium Button",
       selectors: [
         'a[data-testid="premium-hub-tab"]',
+        'a[data-testid="premium-signup-tab"]',
         'a[aria-label="Premium"][role="link"]'
       ]
     },
@@ -61,7 +62,8 @@ const TWITTER_MODS = {
       enabled: false,
       description: "Hide Community Notes Button",
       selectors: [
-        'a[aria-label="Community Notes"][role="link"]'
+        'a[aria-label="Community Notes"][role="link"]',
+        'a[href$="i/communitynotes"]'
       ]
     }
   },

--- a/firefox/config.js
+++ b/firefox/config.js
@@ -54,6 +54,7 @@ const TWITTER_MODS = {
       description: "Hide Premium Button",
       selectors: [
         'a[data-testid="premium-hub-tab"]',
+        'a[data-testid="premium-signup-tab"]',
         'a[aria-label="Premium"][role="link"]'
       ]
     },
@@ -61,7 +62,8 @@ const TWITTER_MODS = {
       enabled: false,
       description: "Hide Community Notes Button",
       selectors: [
-        'a[aria-label="Community Notes"][role="link"]'
+        'a[aria-label="Community Notes"][role="link"]',
+        'a[href$="i/communitynotes"]'
       ]
     }
   },


### PR DESCRIPTION
Community tab and premium buttons did not work on my japanese twitter account, so I added two selectors. Simple 3 lines change. Thanks for the initial work, it's already replaced my previous userscript.
Tested on Brave and Firefox, don't see any reason why it wouldn't work on other chromium skins.