### PR TITLE
Add options to hide Communities and Business buttons

### DIFF
--- a/config.js
+++ b/config.js
@@ -49,6 +49,17 @@ const TWITTER_MODS = {
         'div[role="presentation"]:has(div[style*="background-color: rgb(75, 78, 82)"][style*="border-radius: 9999px"])'
       ]
     },
+    communities: {
+      enabled: false,
+      description: "Hide Communities Button",
+      selectors: [
+        'a[aria-label="Communities"][role="link"]',
+
+        // It's fine to use an href selector: this won't match random links
+        // posted to mysite.com/mycommunities because X will convert them t.co/xyz
+        'a[href$="/communities"]'
+      ]
+    },
     premium: {
       enabled: false,
       description: "Hide Premium Button",

--- a/config.js
+++ b/config.js
@@ -58,6 +58,14 @@ const TWITTER_MODS = {
         'a[aria-label="Premium"][role="link"]'
       ]
     },
+    business: {
+      enabled: false,
+      description: "Hide Business Button",
+      selectors: [
+        'a[aria-label="Business"][role="link"]',
+        'a[href$="i/verified-orgs-signup"]'
+      ],
+    },
     communityNotes: {
       enabled: false,
       description: "Hide Community Notes Button",

--- a/firefox/config.js
+++ b/firefox/config.js
@@ -49,6 +49,17 @@ const TWITTER_MODS = {
         'div[role="presentation"]:has(div[style*="background-color: rgb(75, 78, 82)"][style*="border-radius: 9999px"])'
       ]
     },
+    communities: {
+      enabled: false,
+      description: "Hide Communities Button",
+      selectors: [
+        'a[aria-label="Communities"][role="link"]',
+
+        // It's fine to use an href selector: this won't match random links
+        // posted to mysite.com/mycommunities because X will convert them t.co/xyz
+        'a[href$="/communities"]'
+      ]
+    },
     premium: {
       enabled: false,
       description: "Hide Premium Button",

--- a/firefox/config.js
+++ b/firefox/config.js
@@ -58,6 +58,14 @@ const TWITTER_MODS = {
         'a[aria-label="Premium"][role="link"]'
       ]
     },
+    business: {
+      enabled: false,
+      description: "Hide Business Button",
+      selectors: [
+        'a[aria-label="Business"][role="link"]',
+        'a[href$="i/verified-orgs-signup"]'
+      ],
+    },
     communityNotes: {
       enabled: false,
       description: "Hide Community Notes Button",


### PR DESCRIPTION
Before:
![1737988862](https://github.com/user-attachments/assets/b49c08a2-33d6-426d-8e07-bc8ece04ae9e)

After:
![1737988890](https://github.com/user-attachments/assets/4841098d-c6ba-4a2d-add0-a41800a15325)

I've tested both on Brave (Chromium-based) and Firefox, and see no issues.

(I don't use either button, but feel free to close the PR if you disagree that these could be useful to hide.)