### PR TITLE
Add further "Post" to "Tweet" replacement options

### DIFF
--- a/config.js
+++ b/config.js
@@ -100,9 +100,9 @@ const TWITTER_MODS = {
         height: '24px'
       }
     },
-    tweetButton: {
+    tweetButtonHome: {
       enabled: false,
-      description: "Replace 'Post' with 'Tweet'",
+      description: "Replace 'Post' with 'Tweet' (Home)",
       type: 'buttonReplace',
       target: 'button[data-testid="tweetButtonInline"]',
       replacementData: {
@@ -152,6 +152,106 @@ const TWITTER_MODS = {
             background-color: rgba(29, 155, 240, 0.4) !important;
           }
           button[data-testid="tweetButtonInline"][disabled] div {
+            color: rgb(255, 255, 255) !important;
+          }
+        `
+      }
+    },
+    tweetButtonSidebar: {
+      enabled: false,
+      description: "Replace 'Post' with 'Tweet' (Left)",
+      type: 'buttonReplace',
+      target: 'a[data-testid="SideNav_NewTweet_Button"]',
+      replacementData: {
+        text: 'Tweet',
+        styles: `
+          a[data-testid="SideNav_NewTweet_Button"] span.css-1jxf684 span.css-1jxf684 {
+            display: flex !important;
+            justify-content: center !important;
+            align-items: center !important;
+            width: 100% !important;
+          }
+          /* Empty the text content */
+          a[data-testid="SideNav_NewTweet_Button"] span.css-1jxf684 span.r-poiln3 {
+            text-indent: -9999px !important;
+            font-size: 0 !important;
+          }
+          a[data-testid="SideNav_NewTweet_Button"] span.css-1jxf684 span.css-1jxf684 span::before {
+            position: static !important;
+            transform: none !important;
+            white-space: nowrap !important;
+            content: 'Tweet' !important;
+            text-indent: 0 !important;
+            font-size: 17px !important;
+          }
+          /* Active state */
+          a[data-testid="SideNav_NewTweet_Button"]:not([disabled]) {
+            background-color: rgb(29, 155, 240) !important;
+          }
+          a[data-testid="SideNav_NewTweet_Button"]:not([disabled]) div {
+            color: rgb(255, 255, 255) !important;
+          }
+
+          /* Since we're already changing it to blue, also set the glyph color
+          (used when the window width is small) */
+          a[data-testid="SideNav_NewTweet_Button"] svg, a[data-testid="SideNav_NewTweet_Button"] div[dir="ltr"] {
+            color: white !important;
+          }
+        `
+      }
+    },
+    tweetButtonPopup: {
+      enabled: false,
+      description: "Replace 'Post' with 'Tweet' (Compose Popup)",
+      type: 'buttonReplace',
+      target: 'button[data-testid="tweetButton"]',
+      replacementData: {
+        text: 'Tweet',
+        styles: `
+          /* Button width and text alignment */
+          button[data-testid="tweetButton"] {
+            min-width: 56px !important;
+            width: auto !important;
+            padding: 0 12px !important;
+            height: 32px !important;
+            margin-left: 12px !important;
+          }
+          button[data-testid="tweetButton"] div {
+            justify-content: center !important;
+            align-items: center !important;
+            width: 100% !important;
+          }
+          button[data-testid="tweetButton"] span.css-1jxf684 {
+            display: flex !important;
+            justify-content: center !important;
+            align-items: center !important;
+            width: 100% !important;
+          }
+          /* Empty the text content */
+          button[data-testid="tweetButton"] span.css-1jxf684 span.r-poiln3 {
+            text-indent: -9999px !important;
+            font-size: 0 !important;
+          }
+          button[data-testid="tweetButton"] span.css-1jxf684 span::before {
+            position: static !important;
+            transform: none !important;
+            white-space: nowrap !important;
+            content: 'Tweet' !important;
+            text-indent: 0 !important;
+            font-size: 14px !important;
+          }
+          /* Active state */
+          button[data-testid="tweetButton"]:not([disabled]) {
+            background-color: rgb(29, 155, 240) !important;
+          }
+          button[data-testid="tweetButton"]:not([disabled]) div {
+            color: rgb(255, 255, 255) !important;
+          }
+          /* Disabled state */
+          button[data-testid="tweetButton"][disabled] {
+            background-color: rgba(29, 155, 240, 0.4) !important;
+          }
+          button[data-testid="tweetButton"][disabled] div {
             color: rgb(255, 255, 255) !important;
           }
         `

--- a/firefox/config.js
+++ b/firefox/config.js
@@ -100,9 +100,9 @@ const TWITTER_MODS = {
         height: '24px'
       }
     },
-    tweetButton: {
+    tweetButtonHome: {
       enabled: false,
-      description: "Replace 'Post' with 'Tweet'",
+      description: "Replace 'Post' with 'Tweet' (Home)",
       type: 'buttonReplace',
       target: 'button[data-testid="tweetButtonInline"]',
       replacementData: {
@@ -156,6 +156,106 @@ const TWITTER_MODS = {
           }
         `
       }
+    },
+    tweetButtonSidebar: {
+      enabled: false,
+      description: "Replace 'Post' with 'Tweet' (Left)",
+      type: 'buttonReplace',
+      target: 'a[data-testid="SideNav_NewTweet_Button"]',
+      replacementData: {
+        text: 'Tweet',
+        styles: `
+          a[data-testid="SideNav_NewTweet_Button"] span.css-1jxf684 span.css-1jxf684 {
+            display: flex !important;
+            justify-content: center !important;
+            align-items: center !important;
+            width: 100% !important;
+          }
+          /* Empty the text content */
+          a[data-testid="SideNav_NewTweet_Button"] span.css-1jxf684 span.r-poiln3 {
+            text-indent: -9999px !important;
+            font-size: 0 !important;
+          }
+          a[data-testid="SideNav_NewTweet_Button"] span.css-1jxf684 span.css-1jxf684 span::before {
+            position: static !important;
+            transform: none !important;
+            white-space: nowrap !important;
+            content: 'Tweet' !important;
+            text-indent: 0 !important;
+            font-size: 17px !important;
+          }
+          /* Active state */
+          a[data-testid="SideNav_NewTweet_Button"]:not([disabled]) {
+            background-color: rgb(29, 155, 240) !important;
+          }
+          a[data-testid="SideNav_NewTweet_Button"]:not([disabled]) div {
+            color: rgb(255, 255, 255) !important;
+          }
+
+          /* Since we're already changing it to blue, also set the glyph color
+          (used when the window width is small) */
+          a[data-testid="SideNav_NewTweet_Button"] svg, a[data-testid="SideNav_NewTweet_Button"] div[dir="ltr"] {
+            color: white !important;
+          }
+        `
+      }
+    },
+    tweetButtonPopup: {
+      enabled: false,
+      description: "Replace 'Post' with 'Tweet' (Compose Popup)",
+      type: 'buttonReplace',
+      target: 'button[data-testid="tweetButton"]',
+      replacementData: {
+        text: 'Tweet',
+        styles: `
+          /* Button width and text alignment */
+          button[data-testid="tweetButton"] {
+            min-width: 56px !important;
+            width: auto !important;
+            padding: 0 12px !important;
+            height: 32px !important;
+            margin-left: 12px !important;
+          }
+          button[data-testid="tweetButton"] div {
+            justify-content: center !important;
+            align-items: center !important;
+            width: 100% !important;
+          }
+          button[data-testid="tweetButton"] span.css-1jxf684 {
+            display: flex !important;
+            justify-content: center !important;
+            align-items: center !important;
+            width: 100% !important;
+          }
+          /* Empty the text content */
+          button[data-testid="tweetButton"] span.css-1jxf684 span.r-poiln3 {
+            text-indent: -9999px !important;
+            font-size: 0 !important;
+          }
+          button[data-testid="tweetButton"] span.css-1jxf684 span::before {
+            position: static !important;
+            transform: none !important;
+            white-space: nowrap !important;
+            content: 'Tweet' !important;
+            text-indent: 0 !important;
+            font-size: 14px !important;
+          }
+          /* Active state */
+          button[data-testid="tweetButton"]:not([disabled]) {
+            background-color: rgb(29, 155, 240) !important;
+          }
+          button[data-testid="tweetButton"]:not([disabled]) div {
+            color: rgb(255, 255, 255) !important;
+          }
+          /* Disabled state */
+          button[data-testid="tweetButton"][disabled] {
+            background-color: rgba(29, 155, 240, 0.4) !important;
+          }
+          button[data-testid="tweetButton"][disabled] div {
+            color: rgb(255, 255, 255) !important;
+          }
+        `
+      }
     }
   },
   
@@ -171,9 +271,12 @@ const TWITTER_MODS = {
       styles: `
         margin: 0 auto !important;
         float: none !important;
+        width: 100% !important;
         max-width: 600px !important;
-        width: 600px !important;
-        flex: 0 1 600px !important;
+        flex-grow: 1 !important;
+        flex-basis: auto !important;
+        flex-direction: column !important;
+        flex-shrink: 0 !important;
         -webkit-box-flex: 0 !important;
       `
     },


### PR DESCRIPTION
The current text replacement option only supports the button on the homepage, but I see two other such buttons on the site, which this PR covers.

I've tested it on Brave and Firefox, both on Linux.

<details>
<summary>You can click here to see screenshots of the new display, if needed</summary>

Here's the new left sidebar button appearance:
![after-large](https://github.com/user-attachments/assets/c7d5a7e4-55bf-41d7-acaf-8c8ad29e7474)

Here's the new left sidebar button appearance, when the window is small. For consistency, it adds the same blue color that the "Fix compose button colors" option adds:
![after-small](https://github.com/user-attachments/assets/4628f25e-dd45-4620-ac0b-ddcfc682f66e)

Here's the new popup confirmation button display. It's enabled in this screenshot, but it gets darker when disabled, too, as expected:
![1738448450](https://github.com/user-attachments/assets/43e3c681-39a6-47b1-b048-ab01adc0938a)
</details>

Note that in the compose popup, the text normally switches from "Post" to "Post all" if you're making multiple posts at once. But since we're just setting `content` on a `::before`, and there's no reasonable way to distinguish one/all in CSS, BlueRaven's would always show "Tweet" in both cases. I thought this was acceptable and didn't warrant the complexity of adding tracking in JS.
![0](https://github.com/user-attachments/assets/2495d593-1dc4-4b88-b502-deb048919d88)

---

> [!IMPORTANT]
> Do you think it's a problem that there are now three separate checkboxes for this overarching feature? If you don't expect people to only enable one or two at a time, I could instead merge them into the current option.
> 
> ![0](https://github.com/user-attachments/assets/1addc2f4-9d61-4758-aa0f-3708e55eb1ea)