### PR TITLE
Enable hiding even more stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,11 +67,15 @@ genAI can generally one-shot most features if you feed it the proper HTML - just
 8. The BlueRaven icon should now appear in your toolbar!
 
 ### Firefox
+#### Installing as a temporary Add-On
 1. Visit `about:debugging#/runtime/this-firefox`
 2. Click "Load Temporary Add-on"
 3. Navigate to the `firefox` folder inside BlueRaven
 4. Select `manifest.json` from the Firefox folder
 5. The BlueRaven icon will appear in your toolbar
+
+#### Installing as a permanent Add-On
+See https://wiki.mozilla.org/Add-ons/Extension_Signing#Unbranded_Builds for instructions on installing unsigned extensions.  Then zip the contents of the `firefox` folder (and not the folder itself!) into a zip file, and upload the same to about:addons.
 
 ## 💡 Usage
 1. Click the BlueRaven icon in your browser toolbar

--- a/config.js
+++ b/config.js
@@ -74,6 +74,48 @@ const TWITTER_MODS = {
         'div[data-testid="DMDrawer"]',
       ]
     },
+    shareButton: {
+      enabled: false,
+      description: "Hide Share Button",
+      selectors: [
+        'button[aria-label="Share post"]'
+      ]
+    },
+    moreButton: {
+      enabled: false,
+      description: "Hide More Button",
+      selectors: [
+        'button[aria-label="More"]'
+      ]
+    },
+    socialContext: {
+      enabled: false,
+      description: "Hide \"[X] Reposted\"",
+      selectors: [
+        'span[data-testid="socialContext"]'
+      ]
+    },
+    accountSuggestions: {
+      enabled: false,
+      description: "Hide Account Suggestions",
+      selectors: [
+        'button[data-testid="UserCell"]'
+      ]
+    },
+    trendingNews: {
+      enabled: false,
+      description: "Hide \"News\"",
+      selectors: [
+        'div[data-testid="trend"]'
+      ]
+    },
+    newPostsBanner: {
+      enabled: false,
+      description: "Hide \"[X] Posted\" Banner",
+      selectors: [
+        'button[aria-label^="New posts are available"]'
+      ]
+    },
     userInfo: {
       enabled: false,
       description: "Hide User Info in Timeline",
@@ -278,12 +320,8 @@ const TWITTER_MODS = {
       enabled: false,
       description: "Hide View Counts",
       selectors: [
-        // Target analytics link view counts
-        'a[href$="/analytics"] span[data-testid="app-text-transition-container"]',
-        // Backup using aria-label
-        'a[aria-label*="views"][aria-label*="View post analytics"] span[data-testid="app-text-transition-container"]',
-        // Additional backup using the specific view count icon
-        'a[href$="/analytics"]:has(svg path[d*="M8.75 21V3h2v18h-2z"]) span[data-testid="app-text-transition-container"]'
+        // Hide the entire element, along with the icon
+        'a[aria-label*="View post analytics"]',
       ]
     },
     bookmarkCounts: {

--- a/firefox/config.js
+++ b/firefox/config.js
@@ -74,6 +74,48 @@ const TWITTER_MODS = {
         'div[data-testid="DMDrawer"]',
       ]
     },
+    shareButton: {
+      enabled: false,
+      description: "Hide Share Button",
+      selectors: [
+        'button[aria-label="Share post"]'
+      ]
+    },
+    moreButton: {
+      enabled: false,
+      description: "Hide More Button",
+      selectors: [
+        'button[aria-label="More"]'
+      ]
+    },
+    socialContext: {
+      enabled: false,
+      description: "Hide \"[X] Reposted\"",
+      selectors: [
+        'span[data-testid="socialContext"]'
+      ]
+    },
+    accountSuggestions: {
+      enabled: false,
+      description: "Hide Account Suggestions",
+      selectors: [
+        'button[data-testid="UserCell"]'
+      ]
+    },
+    trendingNews: {
+      enabled: false,
+      description: "Hide \"News\"",
+      selectors: [
+        'div[data-testid="trend"]'
+      ]
+    },
+    newPostsBanner: {
+      enabled: false,
+      description: "Hide \"[X] Posted\" Banner",
+      selectors: [
+        'button[aria-label^="New posts are available"]'
+      ]
+    },
     userInfo: {
       enabled: false,
       description: "Hide User Info in Timeline",
@@ -278,12 +320,8 @@ const TWITTER_MODS = {
       enabled: false,
       description: "Hide View Counts",
       selectors: [
-        // Target analytics link view counts
-        'a[href$="/analytics"] span[data-testid="app-text-transition-container"]',
-        // Backup using aria-label
-        'a[aria-label*="views"][aria-label*="View post analytics"] span[data-testid="app-text-transition-container"]',
-        // Additional backup using the specific view count icon
-        'a[href$="/analytics"]:has(svg path[d*="M8.75 21V3h2v18h-2z"]) span[data-testid="app-text-transition-container"]'
+        // Hide the entire element, along with the icon
+        'a[aria-label*="View post analytics"]',
       ]
     },
     bookmarkCounts: {

--- a/firefox/popup.js
+++ b/firefox/popup.js
@@ -22,7 +22,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       },
       { 
         id: 'hideElements', 
-        title: 'Hide Side Tabs',
+        title: 'Side Tabs',
         filter: key => ['allTabs',
                         'communities',
                         'premium',
@@ -41,7 +41,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       },
       {
         id: 'hideElements',
-        title: 'Hide Elements',
+        title: 'Elements',
         filter: key => ['leftSidebar',
                         'rightSidebar',
                         'bothSidebars',
@@ -49,7 +49,17 @@ document.addEventListener('DOMContentLoaded', async () => {
                         'brokenSpacer',
                         'hidePremiumBadge',
                         'messageDrawer',
-                        'userAvatar',
+                        'shareButton',
+                        'moreButton',
+                        'socialContext',
+                        'accountSuggestions',
+                        'trendingNews',
+                        'newPostsBanner'].includes(key)
+      },
+      {
+        id: 'hideElements',
+        title: 'User Info',
+        filter: key => ['userAvatar',
                         'userName',
                         'userHandle',
                         'userNameAndHandle',

--- a/popup.js
+++ b/popup.js
@@ -23,7 +23,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       },
       { 
         id: 'hideElements', 
-        title: 'Hide Side Tabs',
+        title: 'Side Tabs',
         filter: key => ['allTabs',
                         'communities',
                         'premium',
@@ -42,7 +42,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       },
       {
         id: 'hideElements',
-        title: 'Hide Elements',
+        title: 'Elements',
         filter: key => ['leftSidebar',
                         'rightSidebar',
                         'bothSidebars',
@@ -50,7 +50,17 @@ document.addEventListener('DOMContentLoaded', async () => {
                         'brokenSpacer',
                         'hidePremiumBadge',
                         'messageDrawer',
-                        'userAvatar',
+                        'shareButton',
+                        'moreButton',
+                        'socialContext',
+                        'accountSuggestions',
+                        'trendingNews',
+                        'newPostsBanner'].includes(key)
+      },
+      {
+        id: 'hideElements',
+        title: 'User Info',
+        filter: key => ['userAvatar',
                         'userName',
                         'userHandle',
                         'userNameAndHandle',


### PR DESCRIPTION
Simplify "Hide View Counts" and add new options

- shareButton
- moreButton
- socialContext
- accountSuggestions
- trendingNews
- newPostsBanner

Update instructions for Firefox in README.